### PR TITLE
Mention add-ons page in docs

### DIFF
--- a/src/addons.md
+++ b/src/addons.md
@@ -4,8 +4,7 @@ Anki's capabilities can be extended with add-ons. Add-ons can provide
 features like extra support for specific languages, extra control over
 scheduling, and so on.
 
-To browse the list of available add-ons, select the Tools>Add-ons
-menu item, then click on Get Add-ons.
+To browse the list of available add-ons, access https://ankiweb.net/shared/addons
 
 If you have downloaded an add-on that is not working properly, or if you
 accidentally made a mistake when editing an add-on, you can use the


### PR DESCRIPTION
Wasn't sure how to implement tools -> add-ons in the same paragraph, but this solves

https://forums.ankiweb.net/t/add-ankiweb-feature-to-browse-or-search-for-add-ons/40145/3?u=namelessgo